### PR TITLE
next-auth supported node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ npm run dev
 
 This will install the project and start a local development server at [`localhost:3000`](http://localhost:3000).
 
+> ⚠️ Make sure you've nodejs version ^12.19.0 or ^14.15.0 or ^16.13.0", cause those are the only versions supported by next-auth@beta otherwise you'll get ```"next-auth/react" module not found``` error when you run the app
+
 > ❗️ Make sure your rename the `.env.example` to `.env`
 ### Setting up the database
 


### PR DESCRIPTION
Add warning for the only supported nodejs versions in next-auth cause otherwise when you run `yarn install` it'll install older version which don't have `next-auth/react` and when you try to install it manually you'll get this error

![Screenshot 2021-10-30 173952](https://user-images.githubusercontent.com/72823042/139539831-055fdf34-7d4a-4018-a778-a368f0b9f3c6.png)