### PR TITLE
Setup authorization behind private lessons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ STRIPE_WEBHOOK_SECRET = ""
 # when deploying to Vercel, you can get a connection string from the database on PlanetScale
 DATABASE_URL="mysql://root@127.0.0.1:3309/epic-course-platform"
 SHADOW_DATABASE_URL="mysql://root@127.0.0.1:3310/epic-course-platform"
+
+# Monitoring Errors with Sentry
+SENTRY_DSN="dsn"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+yarn.lock
 
 # testing
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# Sentry
+.sentryclirc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true
+}

--- a/next.config.wizardcopy.js
+++ b/next.config.wizardcopy.js
@@ -1,0 +1,26 @@
+// This file sets a custom webpack configuration to use your Next.js app
+// with Sentry.
+// https://nextjs.org/docs/api-reference/next.config.js/introduction
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+const { withSentryConfig } = require('@sentry/nextjs');
+
+const moduleExports = {
+  // Your existing module.exports
+};
+
+const sentryWebpackPluginOptions = {
+  // Additional config options for the Sentry Webpack plugin. Keep in mind that
+  // the following options are set automatically, and overriding them is not
+  // recommended:
+  //   release, url, org, project, authToken, configFile, stripPrefix,
+  //   urlPrefix, include, ignore
+
+  silent: true, // Suppresses all logs
+  // For all available options, see:
+  // https://github.com/getsentry/sentry-webpack-plugin#options.
+};
+
+// Make sure adding Sentry options is the last code to run before exporting, to
+// ensure that your source maps include changes from all other Webpack plugins
+module.exports = withSentryConfig(moduleExports, sentryWebpackPluginOptions);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@heroicons/react": "^1.0.5",
     "@next-auth/prisma-adapter": "^0.5.2-next.19",
     "@prisma/client": "^3.3.0",
+    "@sentry/nextjs": "^6.13.3",
     "gray-matter": "^4.0.3",
     "micro": "^9.3.4",
     "next": "11.1.2",

--- a/package.json
+++ b/package.json
@@ -14,17 +14,20 @@
     "@next-auth/prisma-adapter": "^0.5.2-next.19",
     "@prisma/client": "^3.3.0",
     "@sentry/nextjs": "^6.13.3",
+    "date-fns": "^2.25.0",
     "gray-matter": "^4.0.3",
     "micro": "^9.3.4",
     "next": "11.1.2",
-    "next-auth": "^4.0.0-beta.4",
+    "next-auth": "^4.0.0-beta.6",
     "next-mdx-remote": "^3.0.6",
     "nodemailer": "^6.7.0",
     "prism-react-renderer": "^1.2.1",
     "react": "17.0.2",
+    "react-content-loader": "^6.0.3",
     "react-dom": "17.0.2",
     "react-hook-form": "^7.17.5",
-    "stripe": "^8.184.0"
+    "stripe": "^8.184.0",
+    "swr": "^1.0.1"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.3.4",

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,61 @@
+import NextErrorComponent from 'next/error';
+
+import * as Sentry from '@sentry/nextjs';
+
+const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
+  if (!hasGetInitialPropsRun && err) {
+    // getInitialProps is not called in case of
+    // https://github.com/vercel/next.js/issues/8592. As a workaround, we pass
+    // err via _app.js so it can be captured
+    Sentry.captureException(err);
+    // Flushing is not required in this case as it only happens on the client
+  }
+
+  return <NextErrorComponent statusCode={statusCode} />;
+};
+
+MyError.getInitialProps = async ({ res, err, asPath }) => {
+  const errorInitialProps = await NextErrorComponent.getInitialProps({
+    res,
+    err,
+  });
+
+  // Workaround for https://github.com/vercel/next.js/issues/8592, mark when
+  // getInitialProps has run
+  errorInitialProps.hasGetInitialPropsRun = true;
+
+  // Running on the server, the response object (`res`) is available.
+  //
+  // Next.js will pass an err on the server if a page's data fetching methods
+  // threw or returned a Promise that rejected
+  //
+  // Running on the client (browser), Next.js will provide an err if:
+  //
+  //  - a page's `getInitialProps` threw or returned a Promise that rejected
+  //  - an exception was thrown somewhere in the React lifecycle (render,
+  //    componentDidMount, etc) that was caught by Next.js's React Error
+  //    Boundary. Read more about what types of exceptions are caught by Error
+  //    Boundaries: https://reactjs.org/docs/error-boundaries.html
+
+  if (err) {
+    Sentry.captureException(err);
+
+    // Flushing before returning is necessary if deploying to Vercel, see
+    // https://vercel.com/docs/platform/limits#streaming-responses
+    await Sentry.flush(2000);
+
+    return errorInitialProps;
+  }
+
+  // If this point is reached, getInitialProps was called without any
+  // information about what the error might be. This is unexpected and may
+  // indicate a bug introduced in Next.js, so record it in Sentry
+  Sentry.captureException(
+    new Error(`_error.js getInitialProps missing data at path: ${asPath}`),
+  );
+  await Sentry.flush(2000);
+
+  return errorInitialProps;
+};
+
+export default MyError;

--- a/pages/api/lessons/[lesson].ts
+++ b/pages/api/lessons/[lesson].ts
@@ -1,0 +1,69 @@
+import { isAfter, parseISO } from 'date-fns';
+import fs from 'fs';
+import matter from 'gray-matter';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getSession } from 'next-auth/react';
+import { MDXRemoteSerializeResult } from 'next-mdx-remote';
+import { serialize } from 'next-mdx-remote/serialize';
+import path from 'path';
+import { LESSONS_PATH } from 'utils/mdxUtils';
+import { prisma } from '../../../lib/prisma';
+
+interface Request extends NextApiRequest {
+  query: {
+    lesson: string;
+  };
+}
+export interface LessonResponse {
+  source: MDXRemoteSerializeResult<Record<string, unknown>> | null;
+  frontMatter: {
+    [key: string]: any | null;
+  };
+}
+interface Response extends NextApiResponse {
+  send(params: LessonResponse): any;
+}
+const handler = async (req: Request, res: Response) => {
+  try {
+    const session = await getSession({ req });
+    const isSessionExpired = session?.expires
+      ? isAfter(new Date(), parseISO(session.expires))
+      : true;
+
+    const email = session?.user?.email;
+
+    const isPaidUser = email
+      ? await prisma.user.findUnique({
+          where: { email },
+        })
+      : false;
+
+    const postFilePath = path.join(LESSONS_PATH, `${req.query.lesson}.mdx`);
+    const source = fs.readFileSync(postFilePath);
+
+    const { content, data } = matter(source);
+
+    if (!isPaidUser || isSessionExpired) {
+      return res.send({
+        source: null,
+        frontMatter: data,
+      });
+    }
+
+    const mdxSource = await serialize(content, {
+      mdxOptions: {
+        remarkPlugins: [],
+        rehypePlugins: [],
+      },
+      scope: data,
+    });
+
+    res.send({
+      source: mdxSource,
+      frontMatter: data,
+    });
+  } catch (error) {
+    throw new Error("Couldn't found this Lesson!");
+  }
+};
+export default handler;

--- a/pages/course/[lesson].tsx
+++ b/pages/course/[lesson].tsx
@@ -51,7 +51,7 @@ const ErrorComponent = () => {
 export default function LessonPage() {
   const router = useRouter();
 
-  const lesson = router.asPath.split('/')[2];
+  const { lesson } = router.query;
   const { data, error } = useSWR<LessonResponse>(
     `${process.env.NEXT_PUBLIC_SERVER_URL}/api/lessons/${lesson}`,
     fetcher,

--- a/pages/course/[lesson].tsx
+++ b/pages/course/[lesson].tsx
@@ -1,98 +1,102 @@
-import fs from 'fs';
-import matter from 'gray-matter';
-import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
-import { serialize } from 'next-mdx-remote/serialize';
+import { LockClosedIcon } from '@heroicons/react/outline';
+import { MDXRemote } from 'next-mdx-remote';
 import Head from 'next/head';
 import Link from 'next/link';
-import path from 'path';
-import { useSession, signOut } from 'next-auth/react';
-
-import { lessonFilePaths, LESSONS_PATH } from '../../utils/mdxUtils';
-import { LockClosedIcon } from '@heroicons/react/outline';
-
-interface Props {
-  source: MDXRemoteSerializeResult;
-  frontMatter: {
-    [key: string]: any;
-  };
-}
+import { LessonResponse } from 'pages/api/lessons/[lesson]';
+import useSWR from 'swr';
+import { fetcher } from 'utils/SWRFetcher';
+import ContentLoader from 'react-content-loader';
+import { useRouter } from 'next/router';
 
 const components = {
   Head,
 };
 
-export default function LessonPage({ source, frontMatter }: Props) {
-  const { data: session, status } = useSession();
+const LoadingSkeleton = () => {
+  return (
+    <div className="flex justify-center max-w-screen-md mx-auto my-24">
+      <ContentLoader
+        speed={2}
+        width={'100%'}
+        height={'100%'}
+        viewBox="0 0 557 305"
+        backgroundColor="#f5f5f5"
+        foregroundColor="#efefef"
+      >
+        <rect x="0" y="0" rx="3" ry="3" width="370" height="30" />
+        <rect x="0" y="190" rx="4" ry="4" width="72" height="15" />
+        <rect x="0" y="90" rx="4" ry="4" width="557" height="15" />
+        <rect x="0" y="115" rx="4" ry="4" width="305" height="15" />
+        <rect x="0" y="140" rx="4" ry="4" width="557" height="15" />
+        <rect x="0" y="165" rx="4" ry="4" width="557" height="15" />
+        <rect x="0" y="215" rx="4" ry="4" width="418" height="15" />
+        <rect x="0" y="240" rx="4" ry="4" width="557" height="15" />
+        <rect x="0" y="265" rx="4" ry="4" width="533" height="15" />
+        <rect x="0" y="290" rx="4" ry="4" width="344" height="15" />
+        <rect x="0" y="43" rx="3" ry="3" width="431" height="21" />
+      </ContentLoader>
+    </div>
+  );
+};
+const ErrorComponent = () => {
+  return (
+    <div className="prose max-w-screen-md mx-auto my-24">
+      <h1> Error: Couldn&apos;t find this Lesson! </h1>
+      <p>
+        Maybe the Lesson was removed by the author, please contact support :D
+      </p>
+    </div>
+  );
+};
+export default function LessonPage() {
+  const router = useRouter();
+
+  const lesson = router.asPath.split('/')[2];
+  const { data, error } = useSWR<LessonResponse>(
+    `${process.env.NEXT_PUBLIC_SERVER_URL}/api/lessons/${lesson}`,
+    fetcher,
+  );
 
   return (
     <>
-      <div className="max-w-screen-md mx-auto my-24">
-        <h1 className="font-bold text-xl mb-3">{frontMatter.title}</h1>
-        <p className="text-lg mb-5">{frontMatter.description}</p>
-        {status === 'authenticated' ? (
-          <main className="prose">
-            <MDXRemote {...source} components={components} />
-          </main>
-        ) : (
-          <div className="rounded-md bg-gray-50 p-4">
-            <div className="flex">
-              <div className="flex-shrink-0">
-                <LockClosedIcon
-                  className="h-5 w-5 text-gray-400"
-                  aria-hidden="true"
-                />
-              </div>
-              <div className="ml-3 flex-1 md:flex md:justify-between">
-                <p className="text-md text-gray-700">
-                  Please log in to access your course or purchase a license
-                </p>
-                <p className="mt-3 text-md md:mt-0 md:ml-6">
-                  <Link href="/course">
-                    <a className="whitespace-nowrap font-medium text-gray-700 hover:text-gray-600">
-                      Details <span aria-hidden="true">&rarr;</span>
-                    </a>
-                  </Link>
-                </p>
+      {data ? (
+        <div className="max-w-screen-md mx-auto my-24">
+          <h1 className="font-bold text-xl mb-3">{data.frontMatter.title}</h1>
+          <p className="text-lg mb-5">{data.frontMatter.description}</p>
+          {data.source ? (
+            <main className="prose">
+              <MDXRemote {...data.source} components={components} />
+            </main>
+          ) : (
+            <div className="rounded-md bg-gray-50 p-4">
+              <div className="flex">
+                <div className="flex-shrink-0">
+                  <LockClosedIcon
+                    className="h-5 w-5 text-gray-400"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="ml-3 flex-1 md:flex md:justify-between">
+                  <p className="text-md text-gray-700">
+                    Please log in to access your course or purchase a license
+                  </p>
+                  <p className="mt-3 text-md md:mt-0 md:ml-6">
+                    <Link href="/course">
+                      <a className="whitespace-nowrap font-medium text-gray-700 hover:text-gray-600">
+                        Details <span aria-hidden="true">&rarr;</span>
+                      </a>
+                    </Link>
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      ) : !error ? (
+        <LoadingSkeleton />
+      ) : (
+        <ErrorComponent />
+      )}
     </>
   );
 }
-
-export const getStaticProps = async ({ params }) => {
-  const postFilePath = path.join(LESSONS_PATH, `${params.lesson}.mdx`);
-  const source = fs.readFileSync(postFilePath);
-
-  const { content, data } = matter(source);
-
-  const mdxSource = await serialize(content, {
-    mdxOptions: {
-      remarkPlugins: [],
-      rehypePlugins: [],
-    },
-    scope: data,
-  });
-
-  return {
-    props: {
-      source: mdxSource,
-      frontMatter: data,
-    },
-  };
-};
-
-export const getStaticPaths = async () => {
-  const paths = lessonFilePaths
-    // Remove file extensions for page paths
-    .map((path) => path.replace(/\.mdx?$/, ''))
-    // Map the path into the static paths object required by Next.js
-    .map((lesson) => ({ params: { lesson } }));
-
-  return {
-    paths,
-    fallback: false,
-  };
-};

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,0 +1,17 @@
+// This file configures the initialization of Sentry on the browser.
+// The config you add here will be used whenever a page is visited.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from '@sentry/nextjs';
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+Sentry.init({
+  dsn: SENTRY_DSN,
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+  // ...
+  // Note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
+});

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,0 +1,4 @@
+defaults.url=https://sentry.io/
+defaults.org=yassin-eldeeb
+defaults.project=course-platform
+cli.executable=..\\..\\..\\..\\Users\\yassi\\AppData\\Local\\npm-cache\\_npx\\a8388072043b4cbc\\node_modules\\@sentry\\cli\\bin\\sentry-cli

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -1,0 +1,17 @@
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from '@sentry/nextjs';
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+Sentry.init({
+  dsn: SENTRY_DSN,
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+  // ...
+  // Note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "baseUrl": "."
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/_error.js"],
   "exclude": ["node_modules"]
 }

--- a/utils/SWRFetcher.ts
+++ b/utils/SWRFetcher.ts
@@ -1,0 +1,1 @@
+export const fetcher = (...args) => fetch(...args).then((res) => res.json());

--- a/utils/SWRFetcher.ts
+++ b/utils/SWRFetcher.ts
@@ -1,1 +1,1 @@
-export const fetcher = (...args) => fetch(...args).then((res) => res.json());
+export const fetcher = (url: string) => fetch(url).then((res) => res.json());


### PR DESCRIPTION
- CSR without data for private lesson page
- SWR for client side fetching
- loading skeleton for the lesson
- `/api/lessons/[lesson]` for authorizing users and sending private lesson data